### PR TITLE
feat(core): introduce `ScenarioOptions` to control scenario execution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
+    <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TinyBDD.MSTest/TinyBddMsTestBase.cs
+++ b/src/TinyBDD.MSTest/TinyBddMsTestBase.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace TinyBDD.MSTest;
 
 /// <summary>
@@ -22,10 +24,40 @@ public abstract class TinyBddMsTestBase
     [TestInitialize]
     public void TinyBdd_Init()
     {
+        Bdd.Register(AmbientTestMethodResolver.Instance);
+        AmbientTestMethodResolver.Set(ResolveCurrentMethod(TestContext));
+        
         MsTestTraitBridge.TestContext = TestContext;
         var traits = new MsTestTraitBridge();
         var ctx = Bdd.CreateContext(this, traits: traits);
         Ambient.Current.Value = ctx;
+    }
+    
+    private static MethodInfo? ResolveCurrentMethod(TestContext tc)
+    {
+        // FullyQualifiedTestClassName is authoritative for the test class.
+        var classType = Type.GetType(tc.FullyQualifiedTestClassName!) ?? null;
+        if (classType is null) return null;
+        
+        // 1) Exact match (typical)
+        var mi = classType.GetMethod(
+            tc.TestName!,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        if (mi is not null) return mi;
+
+        // 2) Data-driven / decorated name: often "MethodName (arg1, arg2, ...)"
+        // Try prefix match first
+        mi = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(m => tc.TestName!.StartsWith(m.Name, StringComparison.Ordinal));
+
+        if (mi is not null) return mi;
+
+        // 3) Fallback: any method carrying [Scenario] (when unique per class)
+        mi = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(m => m.GetCustomAttribute<ScenarioAttribute>() is not null);
+
+        return mi; // may be null; TinyBDD will fall back to stack-walk if needed
     }
 
     /// <summary>Writes a Gherkin report and clears the ambient context.</summary>

--- a/src/TinyBDD.NUnit/TinyBddNUnitBase.cs
+++ b/src/TinyBDD.NUnit/TinyBddNUnitBase.cs
@@ -12,6 +12,7 @@ namespace TinyBDD.NUnit;
 /// <see cref="TinyBdd_TearDown"/>, it emits a Gherkin report and clears the ambient context.
 /// </remarks>
 [Feature("Unnamed Feature")]
+[UseTinyBdd]
 public abstract class TinyBddNUnitBase
 {
     /// <summary>The current scenario context for the running test.</summary>

--- a/src/TinyBDD.NUnit/UseTinyBddAttribute.cs
+++ b/src/TinyBDD.NUnit/UseTinyBddAttribute.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace TinyBDD.NUnit;
+
+/// <summary>
+/// Instructs NUnit to register <see cref="AmbientTestMethodResolver"/> and track the currently
+/// executing test method for TinyBDD.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute can be applied at the class or method level. Before each test executes, it
+/// calls <see cref="Bdd.Register(ITestMethodResolver)"/> with the global
+/// <see cref="AmbientTestMethodResolver.Instance"/> and sets the current <see cref="MethodInfo"/>
+/// from NUnit’s <see cref="ITest"/> metadata. After the test finishes, it clears the ambient
+/// method reference.
+/// </para>
+/// <para>
+/// This makes <see cref="Bdd.CreateContext(object,string,ITraitBridge,ScenarioOptions)"/> capable
+/// of resolving the correct test method without relying on stack walking.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [TestFixture]
+/// [UseTinyBdd]
+/// public class CalculatorTests
+/// {
+///     [Test]
+///     public async Task AddsNumbers()
+///     {
+///         await Flow.Given(() => 1)
+///                   .When("add", x => x + 1)
+///                   .Then("== 2", v => v == 2);
+///     }
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="AmbientTestMethodResolver"/>
+/// <seealso cref="Bdd.Register(ITestMethodResolver)"/>
+/// <seealso cref="Ambient.Current"/>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class UseTinyBddAttribute : NUnitAttribute, ITestAction
+{
+    /// <inheritdoc />
+    public void BeforeTest(ITest test)
+    {
+        Bdd.Register(AmbientTestMethodResolver.Instance);
+        AmbientTestMethodResolver.Set(test.Method?.MethodInfo);
+    }
+
+    /// <inheritdoc />
+    public void AfterTest(ITest test)
+    {
+        AmbientTestMethodResolver.Set(null);
+    }
+
+    /// <summary>
+    /// Indicates that this attribute applies to tests and test cases.
+    /// </summary>
+    public ActionTargets Targets => ActionTargets.Test;
+}

--- a/src/TinyBDD.Xunit/TinyBDD.Xunit.csproj
+++ b/src/TinyBDD.Xunit/TinyBDD.Xunit.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="xunit.abstractions" />
+      <PackageReference Include="xunit.extensibility.core" />
     </ItemGroup>
 
 </Project>

--- a/src/TinyBDD.Xunit/TinyBddXunitBase.cs
+++ b/src/TinyBDD.Xunit/TinyBddXunitBase.cs
@@ -11,6 +11,7 @@ namespace TinyBDD.Xunit;
 /// <see cref="Dispose"/> emits a Gherkin report and clears the ambient context.
 /// </remarks>
 [Feature("Unnamed Feature")]
+[UseTinyBdd]
 public abstract class TinyBddXunitBase : IDisposable
 {
     private readonly ITestOutputHelper _output;

--- a/src/TinyBDD.Xunit/UseTinyBddAttribute.cs
+++ b/src/TinyBDD.Xunit/UseTinyBddAttribute.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace TinyBDD.Xunit;
+
+/// <summary>
+/// Instructs xUnit to register <see cref="AmbientTestMethodResolver"/> and track the currently
+/// executing test method for TinyBDD.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute can be applied at the class or method level. Before each test executes, it
+/// calls <see cref="Bdd.Register(ITestMethodResolver)"/> with the global
+/// <see cref="AmbientTestMethodResolver.Instance"/> and sets the current <see cref="MethodInfo"/>
+/// from xUnit’s test pipeline. After the test finishes, it clears the ambient
+/// method reference.
+/// </para>
+/// <para>
+/// This allows <see cref="Bdd.CreateContext(object,string,ITraitBridge,ScenarioOptions)"/> to
+/// resolve the correct test method reliably even in async scenarios.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [UseTinyBdd]
+/// public class CalculatorTests
+/// {
+///     [Fact]
+///     public async Task AddsNumbers()
+///     {
+///         await Flow.Given(() => 1)
+///                   .When("add", x => x + 1)
+///                   .Then("== 2", v => v == 2);
+///     }
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="AmbientTestMethodResolver"/>
+/// <seealso cref="Bdd.Register(ITestMethodResolver)"/>
+/// <seealso cref="Ambient.Current"/>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class UseTinyBddAttribute : BeforeAfterTestAttribute
+{
+    /// <inheritdoc />
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        Bdd.Register(AmbientTestMethodResolver.Instance);
+        AmbientTestMethodResolver.Set(methodUnderTest);
+    }
+
+    /// <inheritdoc />
+    public override void After(MethodInfo methodUnderTest)
+    {
+        AmbientTestMethodResolver.Set(null);
+    }
+}

--- a/src/TinyBDD.Xunit/packages.lock.json
+++ b/src/TinyBDD.Xunit/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "2.0.3",
         "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
       },
+      "xunit.extensibility.core": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
       "tinybdd": {
         "type": "Project"
       }

--- a/src/TinyBDD/Core/AmbientTestMethodResolver.cs
+++ b/src/TinyBDD/Core/AmbientTestMethodResolver.cs
@@ -1,0 +1,104 @@
+using System.Reflection;
+
+namespace TinyBDD;
+
+/// <summary>
+/// Provides an ambient (per-async-flow) implementation of <see cref="ITestMethodResolver"/> that
+/// stores the current test <see cref="MethodInfo"/> in an <see cref="AsyncLocal{T}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// TinyBDD needs to know the currently executing test method to read attributes like
+/// <see cref="ScenarioAttribute"/> and <see cref="TagAttribute"/>. Test adapters (xUnit, NUnit, MSTest)
+/// can set the active method at the start of each test and clear it afterward. This avoids brittle
+/// stack walking and works well with parallel execution.
+/// </para>
+/// <para>
+/// Typical usage is:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Register the resolver once via <see cref="Bdd.Register(ITestMethodResolver)"/>.</description></item>
+///   <item><description>Set the current method at test start using <see cref="Set(MethodInfo?)"/>.</description></item>
+///   <item><description>Clear it at test end by calling <see cref="Set(MethodInfo?)"/> with <see langword="null"/>.</description></item>
+/// </list>
+/// <para>
+/// If no ambient method is set, TinyBDD may fall back to a stack-trace based resolver (if available).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // MSTest example
+/// [TestInitialize]
+/// public void Init()
+/// {
+///     Bdd.Register(AmbientTestMethodResolver.Instance);
+///     var mi = typeof(MyTests).GetMethod(TestContext.TestName,
+///         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+///     AmbientTestMethodResolver.Set(mi);
+///     Ambient.Current.Value = Bdd.CreateContext(this, traits: new MsTestTraitBridge(TestContext));
+/// }
+///
+/// [TestCleanup]
+/// public void Cleanup()
+/// {
+///     Ambient.Current.Value = null;
+///     AmbientTestMethodResolver.Set(null);
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="ITestMethodResolver"/>
+/// <seealso cref="Bdd.Register(ITestMethodResolver)"/>
+public sealed class AmbientTestMethodResolver : ITestMethodResolver
+{
+    /// <summary>
+    /// Stores the current test <see cref="MethodInfo"/> for the active async context.
+    /// </summary>
+    private static readonly AsyncLocal<MethodInfo?> Current = new();
+
+    /// <summary>
+    /// Gets the singleton instance of <see cref="AmbientTestMethodResolver"/>.
+    /// </summary>
+    /// <remarks>
+    /// Register this instance once (e.g., in a test base class or adapter attribute) with
+    /// <see cref="Bdd.Register(ITestMethodResolver)"/>, then call <see cref="Set(MethodInfo?)"/>
+    /// at the beginning of each test.
+    /// </remarks>
+    public static AmbientTestMethodResolver Instance { get; } = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AmbientTestMethodResolver"/> class.
+    /// </summary>
+    /// <remarks>
+    /// Constructor is private to enforce the singleton pattern; use <see cref="Instance"/>.
+    /// </remarks>
+    private AmbientTestMethodResolver()
+    {
+    }
+
+    /// <summary>
+    /// Sets the current test <see cref="MethodInfo"/> for the active async flow.
+    /// </summary>
+    /// <param name="method">
+    /// The <see cref="MethodInfo"/> representing the test method that is about to run,
+    /// or <see langword="null"/> to clear the ambient value at the end of the test.
+    /// </param>
+    /// <remarks>
+    /// This method is typically invoked by a framework adapter (e.g., an attribute or base class)
+    /// in a per-test setup/teardown hook. Because it uses <see cref="AsyncLocal{T}"/>, it is safe
+    /// to use in parallel test execution scenarios.
+    /// </remarks>
+    public static void Set(MethodInfo? method) => Current.Value = method;
+
+    /// <summary>
+    /// Gets the current test <see cref="MethodInfo"/> previously set for the active async flow.
+    /// </summary>
+    /// <returns>
+    /// The current <see cref="MethodInfo"/> if one has been set via <see cref="Set(MethodInfo?)"/>,
+    /// otherwise <see langword="null"/>.
+    /// </returns>
+    /// <remarks>
+    /// When this returns <see langword="null"/>, TinyBDD may attempt a slower, stack-trace based
+    /// resolution if configured to do so.
+    /// </remarks>
+    public MethodInfo? GetCurrentTestMethod() => Current.Value;
+}

--- a/src/TinyBDD/Core/BddStepException.cs
+++ b/src/TinyBDD/Core/BddStepException.cs
@@ -1,0 +1,15 @@
+namespace TinyBDD;
+
+/// <summary>
+/// Represents an exception that occurs during a BDD (Behavior-Driven Development) step execution.
+/// This class is used to wrap exceptions occurring during the execution of BDD steps, including information about the failed step context such as its kind and title.
+/// </summary>
+[Serializable]
+public class BddStepException(
+    string message,
+    ScenarioContext context,
+    Exception innerException
+) : Exception(message, innerException)
+{
+    public ScenarioContext Context => context;
+}

--- a/src/TinyBDD/Core/ITestMethodResolver.cs
+++ b/src/TinyBDD/Core/ITestMethodResolver.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+
+namespace TinyBDD;
+
+/// <summary>
+/// Provides an abstraction for resolving the currently executing test method.
+/// </summary>
+/// <remarks>
+/// <para>
+/// TinyBDD uses an implementation of this interface to obtain the <see cref="MethodInfo"/> of
+/// the currently running test method, which is then used to read metadata such as
+/// <see cref="ScenarioAttribute"/> or <see cref="TagAttribute"/>.
+/// </para>
+/// <para>
+/// Test framework adapters (xUnit, NUnit, MSTest, etc.) implement this interface to supply
+/// a reliable way of identifying the active test without relying solely on stack walking,
+/// which can be brittle or slow.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // A minimal implementation using an AsyncLocal
+/// public sealed class AmbientTestMethodResolver : ITestMethodResolver
+/// {
+///     private static readonly AsyncLocal&gt;MethodInfo?&lt; Current = new();
+///
+///     public static void Set(MethodInfo? method) => Current.Value = method;
+///
+///     public MethodInfo? GetCurrentTestMethod() => Current.Value;
+/// }
+///
+/// // Registration in test setup
+/// Bdd.Register(AmbientTestMethodResolver.Instance);
+/// AmbientTestMethodResolver.Set(currentMethodInfo);
+/// </code>
+/// </example>
+/// <seealso cref="AmbientTestMethodResolver"/>
+/// <seealso cref="Bdd.Register(ITestMethodResolver)"/>
+public interface ITestMethodResolver
+{
+    /// <summary>
+    /// Returns the <see cref="MethodInfo"/> for the currently executing test method, or
+    /// <see langword="null"/> if no method could be resolved.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="MethodInfo"/> of the active test method, or <see langword="null"/> if
+    /// no method is known for the current execution context.
+    /// </returns>
+    /// <remarks>
+    /// Implementations should ensure this method is safe to call concurrently from multiple
+    /// tests, e.g., by using <see cref="AsyncLocal{T}"/> or other thread/async-safe mechanisms.
+    /// </remarks>
+    MethodInfo? GetCurrentTestMethod();
+}

--- a/src/TinyBDD/Core/Pipeline.cs
+++ b/src/TinyBDD/Core/Pipeline.cs
@@ -1,39 +1,67 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace TinyBDD;
 
+/// <summary>
+/// Identifies the high-level BDD phase of a step: <c>Given</c>, <c>When</c>, or <c>Then</c>.
+/// </summary>
 internal enum StepPhase
 {
+    /// <summary>Setup and preconditions.</summary>
     Given,
+
+    /// <summary>Action or behavior under test.</summary>
     When,
+
+    /// <summary>Verification/assertion.</summary>
     Then
 }
 
+/// <summary>
+/// Identifies the BDD connective used for a step within a phase: primary keyword, <c>And</c>, or <c>But</c>.
+/// </summary>
 internal enum StepWord
 {
+    /// <summary>The primary keyword for the phase (e.g., <c>Given</c>, <c>When</c>, <c>Then</c>).</summary>
     Primary,
+
+    /// <summary>Connective that continues the previous phase: <c>And</c>.</summary>
     And,
+
+    /// <summary>Connective that continues the previous phase with contrast: <c>But</c>.</summary>
     But
 }
 
-internal static class VT
-{
-    public static ValueTask<T> From<T>(T v) => ValueTask.FromResult(v);
-
-    public static ValueTask<T> From<T>(Task<T> t) =>
-        t.IsCompletedSuccessfully ? ValueTask.FromResult(t.Result) : new ValueTask<T>(t);
-}
-
+/// <summary>
+/// Utility for computing the human-readable keyword displayed for a step line
+/// (e.g., <c>Given</c>, <c>When</c>, <c>Then</c>, <c>And</c>, <c>But</c>).
+/// </summary>
 internal static class KindStrings
 {
+    /// <summary>
+    /// Gets the display keyword for a step based on its phase and connective.
+    /// </summary>
+    /// <param name="phase">The BDD phase.</param>
+    /// <param name="word">The connective for the step.</param>
+    /// <returns>
+    /// <c>And</c> or <c>But</c> for connective steps; otherwise the phase name (<c>Given</c>, <c>When</c>, <c>Then</c>).
+    /// </returns>
     public static string For(StepPhase phase, StepWord word)
         => word switch { StepWord.And => "And", StepWord.But => "But", _ => phase.ToString() };
 }
 
+/// <summary>
+/// Minimal assertion helper used by TinyBDD step implementations.
+/// </summary>
 internal static class AssertUtil
 {
+    /// <summary>
+    /// Throws <see cref="BddAssertException"/> if the provided condition is <see langword="false"/>.
+    /// </summary>
+    /// <param name="ok">Condition to validate.</param>
+    /// <param name="title">Assertion title used for error reporting.</param>
+    /// <exception cref="BddAssertException">Thrown when <paramref name="ok"/> is <see langword="false"/>.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Ensure(bool ok, string title)
     {
@@ -41,12 +69,63 @@ internal static class AssertUtil
     }
 }
 
+/// <summary>
+/// Executes a queued series of BDD steps for a single scenario, recording timing and results
+/// into the owning <see cref="ScenarioContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pipeline is a single-consumer queue that executes steps in FIFO order. Each step receives the
+/// previous step’s state object and may return a new state. Timing, keyword, title, and any error are
+/// captured as <see cref="StepResult"/> entries in <see cref="ScenarioContext.Steps"/>.
+/// </para>
+/// <para>
+/// Behavior is governed by <see cref="ScenarioOptions"/>:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="ScenarioOptions.ContinueOnError"/> — continue executing after non-assert exceptions.</description></item>
+///   <item><description><see cref="ScenarioOptions.HaltOnFailedAssertion"/> — rethrow <see cref="BddAssertException"/> failures immediately.</description></item>
+///   <item><description><see cref="ScenarioOptions.StepTimeout"/> — optional per-step timeout.</description></item>
+///   <item><description><see cref="ScenarioOptions.MarkRemainingAsSkippedOnFailure"/> — mark enqueued steps as skipped when aborting.</description></item>
+/// </list>
+/// <para>
+/// Two optional hooks, <see cref="BeforeStep"/> and <see cref="AfterStep"/>, enable lightweight telemetry or logging
+/// around each step. Hooks are invoked synchronously on the executing thread.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Enqueue steps
+/// var pipe = new Pipeline(ctx);
+/// pipe.Enqueue(StepPhase.Given, StepWord.Primary, "seed", async (s, ct) => 1);
+/// pipe.EnqueueInherit("double", async (s, ct) => (object?)((int?)s ?? 0 * 2), StepWord.And);
+/// await pipe.RunAsync(CancellationToken.None);
+/// </code>
+/// </example>
+/// <seealso cref="ScenarioContext"/>
+/// <seealso cref="ScenarioOptions"/>
 internal sealed class Pipeline(ScenarioContext ctx)
 {
     private object? _state;
     private StepPhase _lastPhase = StepPhase.Given;
-    private readonly ConcurrentQueue<Step> _steps = new();
+    private readonly Queue<Step> _steps = new();
 
+    /// <summary>
+    /// Optional hook invoked immediately before a step executes.
+    /// </summary>
+    /// <remarks>
+    /// The provided <see cref="StepMetadata"/> contains the computed keyword, title, phase, and connective for the step.
+    /// </remarks>
+    public Action<ScenarioContext, StepMetadata>? BeforeStep { get; init; }
+
+    /// <summary>
+    /// Optional hook invoked after a step completes and its <see cref="StepResult"/> has been added to the context.
+    /// </summary>
+    public Action<ScenarioContext, StepResult>? AfterStep { get; init; }
+
+    /// <summary>
+    /// Represents a single enqueued step. Each step receives the prior state and returns the next state.
+    /// </summary>
     private readonly struct Step(
         StepPhase phase,
         StepWord word,
@@ -54,12 +133,46 @@ internal sealed class Pipeline(ScenarioContext ctx)
         Func<object?, CancellationToken, ValueTask<object?>> exec
     )
     {
+        /// <summary>The BDD phase for the step.</summary>
         public readonly StepPhase Phase = phase;
+
+        /// <summary>The connective keyword (<c>Primary</c>, <c>And</c>, <c>But</c>).</summary>
         public readonly StepWord Word = word;
+
+        /// <summary>Human-friendly title displayed in reports.</summary>
         public readonly string Title = title;
+
+        /// <summary>The delegate that executes the step and returns the next state.</summary>
         public readonly Func<object?, CancellationToken, ValueTask<object?>> Exec = exec;
+
+        /// <summary>
+        /// Computes and returns the display keyword for the step (e.g., <c>Given</c>, <c>And</c>).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string KindCached() => KindStrings.For(Phase, Word);
     }
 
+    /// <summary>
+    /// Metadata sent to <see cref="BeforeStep"/> describing a step about to execute.
+    /// </summary>
+    /// <param name="Kind">The display keyword for the step (e.g., <c>Given</c>, <c>And</c>).</param>
+    /// <param name="Title">The step title.</param>
+    /// <param name="Phase">The BDD phase.</param>
+    /// <param name="Word">The connective keyword.</param>
+    public readonly record struct StepMetadata(
+        string Kind,
+        string Title,
+        StepPhase Phase,
+        StepWord Word
+    );
+
+    /// <summary>
+    /// Enqueues a step with explicit phase, connective, title, and executor.
+    /// </summary>
+    /// <param name="phase">The BDD phase (<see cref="StepPhase"/>).</param>
+    /// <param name="word">The connective keyword (<see cref="StepWord"/>).</param>
+    /// <param name="title">Human-friendly title for reporting.</param>
+    /// <param name="exec">The function that executes the step, receiving prior state and a token, returning next state.</param>
     public void Enqueue(
         StepPhase phase,
         StepWord word,
@@ -70,35 +183,159 @@ internal sealed class Pipeline(ScenarioContext ctx)
         _steps.Enqueue(new Step(phase, word, title, exec));
     }
 
-    public void EnqueueInherit(string title, Func<object?, CancellationToken, ValueTask<object?>> exec, StepWord word)
+    /// <summary>
+    /// Enqueues a step that inherits the previously enqueued phase, specifying only title, executor, and connective.
+    /// </summary>
+    /// <param name="title">Human-friendly title for reporting.</param>
+    /// <param name="exec">The function that executes the step.</param>
+    /// <param name="word">The connective keyword.</param>
+    public void EnqueueInherit(
+        string title,
+        Func<object?, CancellationToken, ValueTask<object?>> exec,
+        StepWord word)
         => Enqueue(_lastPhase, word, title, exec);
 
+    /// <summary>
+    /// Executes all enqueued steps in FIFO order, recording results to <paramref name="ctx"/>.
+    /// </summary>
+    /// <param name="ct">Cancellation token that aborts execution between or during steps.</param>
+    /// <remarks>
+    /// <para>
+    /// On success or handled failure, each step produces a <see cref="StepResult"/> captured in the scenario context.
+    /// When <see cref="ScenarioOptions.ContinueOnError"/> is <see langword="false"/>, non-assert exceptions
+    /// cause a <see cref="BddStepException"/> to be thrown after the failing step is recorded. When
+    /// <see cref="ScenarioOptions.MarkRemainingAsSkippedOnFailure"/> is enabled, remaining steps are recorded as skipped.
+    /// </para>
+    /// <para>
+    /// If <see cref="ScenarioOptions.HaltOnFailedAssertion"/> is <see langword="true"/>, a <see cref="BddAssertException"/>
+    /// will be rethrown immediately after recording, halting the pipeline. Otherwise the failure is recorded and
+    /// execution continues according to <see cref="ScenarioOptions.ContinueOnError"/>.
+    /// </para>
+    /// <para>
+    /// If <see cref="ScenarioOptions.StepTimeout"/> is set, each step runs under a linked cancellation source that
+    /// cancels after the configured timeout.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="ct"/> is canceled.</exception>
+    /// <exception cref="BddStepException">Thrown when a step throws and <see cref="ScenarioOptions.ContinueOnError"/> is <see langword="false"/>.</exception>
     public async ValueTask RunAsync(CancellationToken ct)
     {
-        while (_steps.TryDequeue(out var step))
+        var continueOnError = ctx.Options.ContinueOnError;
+        var stepTimeout = ctx.Options.StepTimeout;
+        var markRemainingAsSkipped = ctx.Options.MarkRemainingAsSkippedOnFailure;
+        var haltOnFailedAssert = ctx.Options.HaltOnFailedAssertion;
+
+        while (_steps.Count > 0)
         {
+            ct.ThrowIfCancellationRequested();
+
+            var step = _steps.Dequeue();
+            var title = string.IsNullOrWhiteSpace(step.Title)
+                ? step.Phase.ToString()
+                : step.Title;
+            var kind = step.KindCached();
             var sw = Stopwatch.StartNew();
+
             Exception? err = null;
+            var canceled = false;
+            var captured = false;
+
+            BeforeStep?.Invoke(ctx, new StepMetadata(kind, title, step.Phase, step.Word));
+
             try
             {
-                _state = await step.Exec(_state, ct);
+                if (stepTimeout is { } timeout)
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    cts.CancelAfter(timeout);
+                    _state = await step.Exec(_state, cts.Token);
+                }
+                else
+                {
+                    _state = await step.Exec(_state, ct);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Cooperative cancellation from the caller; record and rethrow after finally.
+                canceled = true;
+                err = null;
+            }
+            catch (BddAssertException ex)
+            {
+                // Then/verification failure. Record and optionally halt depending on options.
+                err = ex;
+                if (haltOnFailedAssert)
+                    throw;
             }
             catch (Exception ex)
             {
-                // Trap & record; DO NOT rethrow
+                // Non-assert failures.
                 err = ex;
+                if (!continueOnError)
+                {
+                    CaptureStepResult();
+
+                    if (markRemainingAsSkipped)
+                        DrainAsSkipped();
+
+                    throw new BddStepException(
+                        $"Step failed: {step.KindCached()} {title}", ctx, ex);
+                }
             }
             finally
             {
+                CaptureStepResult();
+            }
+
+            if (canceled)
+                ct.ThrowIfCancellationRequested();
+
+            continue;
+
+            // Local helper to ensure we add the step result exactly once, even if we throw later.
+            void CaptureStepResult()
+            {
                 sw.Stop();
-                ctx.AddStep(new StepResult
+
+                var result = new StepResult
                 {
-                    Kind = KindStrings.For(step.Phase, step.Word),
-                    Title = string.IsNullOrWhiteSpace(step.Title) ? step.Phase.ToString() : step.Title,
+                    Kind = kind,
+                    Title = title,
                     Elapsed = sw.Elapsed,
                     Error = err
-                });
+                };
+
+                if (captured)
+                    return;
+
+                captured = true;
+
+                ctx.AddStep(result);
+                AfterStep?.Invoke(ctx, result);
             }
+        }
+    }
+
+    /// <summary>
+    /// Drains any remaining steps and records each as skipped due to a prior failure.
+    /// </summary>
+    private void DrainAsSkipped()
+    {
+        while (_steps.Count > 0)
+        {
+            var pending = _steps.Dequeue();
+            var title = string.IsNullOrWhiteSpace(pending.Title)
+                ? pending.Phase.ToString()
+                : pending.Title;
+
+            ctx.AddStep(new StepResult
+            {
+                Kind = KindStrings.For(pending.Phase, pending.Word),
+                Title = title,
+                Elapsed = TimeSpan.Zero,
+                Error = new InvalidOperationException("Skipped due to previous failure.")
+            });
         }
     }
 }

--- a/src/TinyBDD/Core/ScenarioBuilder.cs
+++ b/src/TinyBDD/Core/ScenarioBuilder.cs
@@ -46,7 +46,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.And, title, (s, _) =>
         {
             assertion((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -131,7 +131,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.And, title, (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), title);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -204,7 +204,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.And, "", (s, _) =>
         {
             assertion((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -283,7 +283,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.And, "", (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), "And");
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -354,7 +354,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.But, title, (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), title);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -368,7 +368,7 @@ public readonly struct ThenChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.But, "", (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), "But");
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }

--- a/src/TinyBDD/Core/ScenarioChain.cs
+++ b/src/TinyBDD/Core/ScenarioChain.cs
@@ -52,7 +52,8 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> When<TOut>(string title, Func<T, TOut> f)
     {
-        _p.Enqueue(StepPhase.When, StepWord.Primary, title, (s, _) => VT.From((object?)f((T)s!)));
+        _p.Enqueue(StepPhase.When, StepWord.Primary, title, (s, _) => 
+            ValueTask.FromResult((object?)f((T)s!)));
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -89,7 +90,7 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> When<TOut>(Func<T, TOut> f)
     {
-        _p.Enqueue(StepPhase.When, StepWord.Primary, "", (s, _) => VT.From((object?)f((T)s!)));
+        _p.Enqueue(StepPhase.When, StepWord.Primary, "", (s, _) => ValueTask.FromResult((object?)f((T)s!)));
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -142,7 +143,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.When, StepWord.Primary, title, (s, _) =>
         {
             effect((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -219,7 +220,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.When, StepWord.Primary, "", (s, _) =>
         {
             effect((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return this;
     }
@@ -283,7 +284,7 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> And<TOut>(string title, Func<T, TOut> f)
     {
-        _p.EnqueueInherit(title, (s, _) => VT.From((object?)f((T)s!)), StepWord.And);
+        _p.EnqueueInherit(title, (s, _) => ValueTask.FromResult((object?)f((T)s!)), StepWord.And);
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -338,7 +339,7 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> But<TOut>(string title, Func<T, TOut> f)
     {
-        _p.EnqueueInherit(title, (s, _) => VT.From((object?)f((T)s!)), StepWord.But);
+        _p.EnqueueInherit(title, (s, _) => ValueTask.FromResult((object?)f((T)s!)), StepWord.But);
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -392,7 +393,7 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> And<TOut>(Func<T, TOut> f)
     {
-        _p.EnqueueInherit("", (s, _) => VT.From((object?)f((T)s!)), StepWord.And);
+        _p.EnqueueInherit("", (s, _) => ValueTask.FromResult((object?)f((T)s!)), StepWord.And);
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -442,7 +443,7 @@ public sealed class ScenarioChain<T>
     /// <returns>A new <see cref="ScenarioChain{TOut}"/> carrying the transformed value.</returns>
     public ScenarioChain<TOut> But<TOut>(Func<T, TOut> f)
     {
-        _p.EnqueueInherit("", (s, _) => VT.From((object?)f((T)s!)), StepWord.But);
+        _p.EnqueueInherit("", (s, _) => ValueTask.FromResult((object?)f((T)s!)), StepWord.But);
         return new ScenarioChain<TOut>(_p);
     }
 
@@ -495,7 +496,7 @@ public sealed class ScenarioChain<T>
         _p.EnqueueInherit(title, (s, _) =>
         {
             effect((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         }, StepWord.And);
         return this;
     }
@@ -565,7 +566,7 @@ public sealed class ScenarioChain<T>
         _p.EnqueueInherit(title, (s, _) =>
         {
             effect((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         }, StepWord.But);
         return this;
     }
@@ -634,7 +635,7 @@ public sealed class ScenarioChain<T>
         _p.EnqueueInherit("", (s, _) =>
         {
             effect((T)s!);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         }, StepWord.And);
         return this;
     }
@@ -701,7 +702,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.Primary, title, (s, _) =>
         {
             AssertUtil.Ensure(predicate(), title);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return new ThenChain<T>(_p);
     }
@@ -716,7 +717,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.Primary, title, (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), title);
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return new ThenChain<T>(_p);
     }
@@ -843,7 +844,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.Primary, "", (s, _) =>
         {
             AssertUtil.Ensure(predicate((T)s!), "Then");
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return new ThenChain<T>(_p);
     }
@@ -922,7 +923,7 @@ public sealed class ScenarioChain<T>
         _p.Enqueue(StepPhase.Then, StepWord.Primary, "", (s, _) =>
         {
             AssertUtil.Ensure(predicate(), "Then");
-            return VT.From(s);
+            return ValueTask.FromResult(s);
         });
         return new ThenChain<T>(_p);
     }

--- a/src/TinyBDD/Core/ScenarioOptions.cs
+++ b/src/TinyBDD/Core/ScenarioOptions.cs
@@ -1,0 +1,25 @@
+namespace TinyBDD;
+
+public record ScenarioOptions
+{
+    /// <summary>
+    /// If true, the scenario will continue executing steps even if one or more previous steps have failed.
+    /// Defaults to false.
+    /// </summary>
+    public bool ContinueOnError { get; init; } 
+    
+    /// <summary>
+    /// If true, all remaining steps will be marked as skipped if the scenario fails.
+    /// </summary>
+    public bool MarkRemainingAsSkippedOnFailure { get; init; }
+    
+    /// <summary>
+    /// If set, all steps will be timed out after the specified duration.
+    /// </summary>
+    public TimeSpan? StepTimeout { get; init; }
+    
+    /// <summary>
+    /// If true, the scenario will halt execution on the first failed assertion.
+    /// </summary>
+    public bool HaltOnFailedAssertion { get; init; } 
+}

--- a/src/TinyBDD/Properties/AssemblyInfo.cs
+++ b/src/TinyBDD/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TinyBDD.Tests.Common")]
+// If you use Moq or other proxy libraries against internal types:
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/tests/TinyBDD.MSTest.Tests/FakeTestContext.cs
+++ b/tests/TinyBDD.MSTest.Tests/FakeTestContext.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+
+namespace TinyBDD.MSTest.Tests;
+
+internal sealed class FakeTestContext : TestContext
+{
+    public override IDictionary Properties { get; } = new Dictionary<string, object>();
+    public override string? FullyQualifiedTestClassName { get; }
+    public override string? TestName { get; }
+    public List<string> Lines { get; } = new();
+
+    public FakeTestContext(string? fqcn, string? testName)
+    {
+        FullyQualifiedTestClassName = fqcn;
+        TestName = testName;
+    }
+
+    public override void Write(string format, params object[] args) => Lines.Add(string.Format(format, args));
+    public override void WriteLine(string format, params object[] args) => Lines.Add(string.Format(format, args));
+    public override void WriteLine(string message) => Lines.Add(message);
+
+    // --- Required abstract members we don't use in tests ---
+    public override void AddResultFile(string fileName)
+    {
+        // no-op; we just collect logs in-memory
+    }
+
+    public override void Write(string? message)
+    {
+        if (message is not null)
+            Lines.Add(message);
+    }
+
+    public override void DisplayMessage(MessageLevel messageLevel, string message)
+    {
+        // Could store level for inspection if needed
+        Lines.Add($"[{messageLevel}] {message}");
+    }
+}
+
+// Public driver that lets tests call init/cleanup manually
+public sealed class MsBaseDriver : TinyBddMsTestBase
+{
+    public void SetContext(TestContext tc) => TestContext = tc;
+    public void CallInit() => TinyBdd_Init();
+    public void CallCleanup() => TinyBdd_Cleanup();
+    public ScenarioContext? Current => Ambient.Current.Value;
+}
+
+// Helper to get the FQCN string MSTest normally provides
+internal static class Fqcn
+{
+    public static string Of<T>() => typeof(T).AssemblyQualifiedName!;
+    public static string Of(Type t) => t.AssemblyQualifiedName!;
+}

--- a/tests/TinyBDD.MSTest.Tests/MsProbeTypes.cs
+++ b/tests/TinyBDD.MSTest.Tests/MsProbeTypes.cs
@@ -1,0 +1,35 @@
+namespace TinyBDD.MSTest.Tests;
+
+public static class MsProbeTypes
+{
+    [Feature("Probe")]
+    public sealed class Exact
+    {
+        [Scenario("exact")]
+        public void TestExact()
+        {
+        }
+    }
+
+    [Feature("Probe")]
+    public sealed class Prefix
+    {
+        [Scenario("prefix")]
+        public void TestPrefix()
+        {
+        }
+    }
+
+    [Feature("Probe")]
+    public sealed class ScenarioFallback
+    {
+        [Scenario("fallback")]
+        public void UniqueScenarioMethod()
+        {
+        }
+
+        public void Helper()
+        {
+        }
+    }
+}

--- a/tests/TinyBDD.MSTest.Tests/TinyBddMsTestBaseTests.cs
+++ b/tests/TinyBDD.MSTest.Tests/TinyBddMsTestBaseTests.cs
@@ -1,0 +1,106 @@
+// TinyBDD.MSTest.Tests/TinyBddMsTestBaseTests.cs
+
+namespace TinyBDD.MSTest.Tests;
+
+[Feature("MSTest base coverage")]
+[TestClass]
+public class TinyBddMsTestBaseTests
+{
+    private static FakeTestContext Ctx(string fqcn, string name) => new(fqcn, name);
+
+    [Scenario("ResolveCurrentMethod picks exact method by name")]
+    [TestMethod]
+    public void Init_Resolves_Exact_Method()
+    {
+        var type = typeof(MsProbeTypes.Exact);
+        var ctx = Ctx(Fqcn.Of(type), nameof(MsProbeTypes.Exact.TestExact));
+        var drv = new MsBaseDriver();
+
+        drv.SetContext(ctx);
+        drv.CallInit();
+
+        var mi = AmbientTestMethodResolver.Instance.GetCurrentTestMethod();
+        Assert.IsNotNull(mi);
+        Assert.AreEqual(type, mi.DeclaringType);
+        Assert.AreEqual(nameof(MsProbeTypes.Exact.TestExact), mi.Name);
+        Assert.IsNotNull(drv.Current);
+
+        drv.CallCleanup();
+        Assert.IsNull(Ambient.Current.Value);
+    }
+
+    [Scenario("ResolveCurrentMethod picks method by prefix for data-driven names")]
+    [TestMethod]
+    public void Init_Resolves_Prefix_Name()
+    {
+        var type = typeof(MsProbeTypes.Prefix);
+        // Simulate MSTest display like: "TestPrefix (1, 2)"
+        var ctx = Ctx(Fqcn.Of(type), nameof(MsProbeTypes.Prefix.TestPrefix) + " (1, 2)");
+        var drv = new MsBaseDriver();
+
+        drv.SetContext(ctx);
+        drv.CallInit();
+
+        var mi = AmbientTestMethodResolver.Instance.GetCurrentTestMethod();
+        Assert.IsNotNull(mi);
+        Assert.AreEqual(type, mi.DeclaringType);
+        Assert.AreEqual(nameof(MsProbeTypes.Prefix.TestPrefix), mi.Name);
+
+        drv.CallCleanup();
+        Assert.IsNull(Ambient.Current.Value);
+    }
+
+    [Scenario("ResolveCurrentMethod falls back to [Scenario]-decorated method")]
+    [TestMethod]
+    public void Init_Resolves_Scenario_Fallback()
+    {
+        var type = typeof(MsProbeTypes.ScenarioFallback);
+        var ctx = Ctx(Fqcn.Of(type), "DoesNotExist");
+        var drv = new MsBaseDriver();
+
+        drv.SetContext(ctx);
+        drv.CallInit();
+
+        var mi = AmbientTestMethodResolver.Instance.GetCurrentTestMethod();
+        Assert.IsNotNull(mi);
+        Assert.AreEqual(nameof(MsProbeTypes.ScenarioFallback.UniqueScenarioMethod), mi.Name);
+
+        drv.CallCleanup();
+        Assert.IsNull(Ambient.Current.Value);
+    }
+
+    [Scenario("ResolveCurrentMethod returns null when type cannot be loaded")]
+    [TestMethod]
+    public void Init_When_Type_Not_Found_Sets_Null_Method()
+    {
+        var ctx = Ctx("Bogus.Namespace.Type, Bogus.Assembly", "Whatever");
+        var drv = new MsBaseDriver();
+
+        drv.SetContext(ctx);
+        drv.CallInit();
+
+        var mi = AmbientTestMethodResolver.Instance.GetCurrentTestMethod();
+        Assert.IsNull(mi);
+        Assert.IsNotNull(drv.Current);
+
+        drv.CallCleanup();
+        Assert.IsNull(Ambient.Current.Value);
+    }
+
+    [Scenario("Cleanup writes report only when a context exists and is a no-op otherwise")]
+    [TestMethod]
+    public void Cleanup_With_And_Without_Context()
+    {
+        var type = typeof(MsProbeTypes.Exact);
+        var drv = new MsBaseDriver();
+
+        // init → cleanup path (report written, ambient cleared)
+        drv.SetContext(Ctx(Fqcn.Of(type), nameof(MsProbeTypes.Exact.TestExact)));
+        drv.CallInit();
+        drv.CallCleanup();
+        Assert.IsNull(Ambient.Current.Value);
+
+        // cleanup without init → no throw
+        drv.CallCleanup();
+    }
+}

--- a/tests/TinyBDD.Tests.Common/BddGivenOverloadsTests.cs
+++ b/tests/TinyBDD.Tests.Common/BddGivenOverloadsTests.cs
@@ -3,7 +3,9 @@ namespace TinyBDD.Tests.Common;
 public class BddGivenOverloadsTests
 {
     [Feature("GivenOverloads")]
-    private sealed class Host {}
+    private sealed class Host
+    {
+    }
 
     [Scenario("Given(ctx, Func<T>) without title uses default and executes")]
     [Fact]
@@ -32,5 +34,30 @@ public class BddGivenOverloadsTests
         Assert.Equal("Given String", ctx.Steps[0].Title);
         ctx.AssertPassed();
     }
-}
 
+    [Scenario("Given(ctx, string, Func<T>) with title executes")]
+    [Fact]
+    public async Task Given_WithTitle_Sync()
+    {
+        var ctx = Bdd.CreateContext(new Host());
+        await Bdd.Given(ctx, "start", () => 5)
+            .When("noop", (_, _) => Task.CompletedTask)
+            .Then("ok", () => Task.CompletedTask);
+
+        Assert.Equal("start", ctx.Steps[0].Title);
+        ctx.AssertPassed();
+    }
+    
+    [Scenario("Given(ctx, Func<CancellationToken, ValueTask<T>>) without title uses default and executes")]
+    [Fact]
+    public async Task Given_NoTitle_ValueTask()
+    {
+        var ctx = Bdd.CreateContext(new Host());
+        await Bdd.Given(ctx, _ => new ValueTask<string>("abc"))
+            .When("noop", (_, _) => Task.CompletedTask)
+            .Then("ok", () => Task.CompletedTask);
+        
+        Assert.Equal("Given String", ctx.Steps[0].Title);
+        ctx.AssertPassed();   
+    }
+}

--- a/tests/TinyBDD.Tests.Common/BddStepExceptionTests.cs
+++ b/tests/TinyBDD.Tests.Common/BddStepExceptionTests.cs
@@ -16,14 +16,50 @@ public class BddStepExceptionTests
 
         var boom = new InvalidOperationException("boom!");
 
+        var exception = await Assert.ThrowsAsync<BddStepException>(async () =>
+            await Bdd.Given(ctx, "Wire-up", () => 1)
+                .When("Explode", (_, _) => Task.FromException(boom))
+                .Then("Unreached", _ => Task.CompletedTask));
+        
+        Assert.Same(boom, exception.InnerException);
+        Assert.Same(exception.Context, ctx);
+
+        var lastUnerrored = ctx.Steps.Last(x => x.Error != null);
+        Assert.Equal("When", lastUnerrored.Kind);
+        Assert.Equal("Explode", lastUnerrored.Title);
+        Assert.NotNull(lastUnerrored.Error);
+        
+        var lastItem = ctx.Steps.Last();
+        Assert.Equal("When", lastItem.Kind);
+        Assert.Equal("Explode", lastItem.Title);
+        Assert.NotNull(lastItem.Error);
+    }
+
+
+    [Scenario("Exception wrapping with continue on error")]
+    [Fact]
+    public async Task Wraps_Inner_Exception_And_Logs_Failed_Step_On_ContinueOnError()
+    {
+        var host = new Host();
+        var ctx = Bdd.CreateContext(host, options: new ScenarioOptions
+        {
+            ContinueOnError = true
+        });
+
+        var boom = new InvalidOperationException("boom!");
 
         await Bdd.Given(ctx, "Wire-up", () => 1)
             .When("Explode", (_, _) => Task.FromException(boom))
-            .Then("Unreached", _ => Task.CompletedTask);
+            .Then("Reached", _ => Task.CompletedTask);
 
-        var last = ctx.Steps.Last(x => x.Error != null);
-        Assert.Equal("When", last.Kind);
-        Assert.Equal("Explode", last.Title);
-        Assert.NotNull(last.Error);
+        var lastUnerrored = ctx.Steps.Last(x => x.Error != null);
+        Assert.Equal("When", lastUnerrored.Kind);
+        Assert.Equal("Explode", lastUnerrored.Title);
+        Assert.NotNull(lastUnerrored.Error);
+        
+        var lastItem = ctx.Steps.Last();
+        Assert.Equal("Then", lastItem.Kind);
+        Assert.Equal("Reached", lastItem.Title);
+        Assert.Null(lastItem.Error);
     }
 }

--- a/tests/TinyBDD.Tests.Common/NullTraitBridgeTests.cs
+++ b/tests/TinyBDD.Tests.Common/NullTraitBridgeTests.cs
@@ -5,7 +5,7 @@ public class NullTraitBridgeTests
     [Fact]
     public void AddTag_Does_Not_Throw_And_Tags_Are_Still_In_Context()
     {
-        var ctx = new ScenarioContext("F", null, "S", new NullTraitBridge());
+        var ctx = new ScenarioContext("F", null, "S", new NullTraitBridge(), new ScenarioOptions());
         ctx.AddTag("a");
         ctx.AddTag("b");
 

--- a/tests/TinyBDD.Tests.Common/PipelineHookTests.cs
+++ b/tests/TinyBDD.Tests.Common/PipelineHookTests.cs
@@ -1,0 +1,217 @@
+namespace TinyBDD.Tests.Common;
+
+public class PipelineHookTests
+{
+    [Feature("Pipeline")]
+    private sealed class Host { }
+
+    private static ScenarioContext NewContext() =>
+        Bdd.CreateContext(new Host(), options: new ScenarioOptions());
+
+    private static Func<object?, CancellationToken, ValueTask<object?>> Const(object? value) =>
+        (_, _) => new ValueTask<object?>(value);
+
+    private static Func<object?, CancellationToken, ValueTask<object?>> Noop() =>
+        (_, _) => new ValueTask<object?>(new {});
+
+    [Scenario("BeforeStep supplies correct metadata (Kind, Title, Phase, Word) and honors inherited phase")]
+    [Fact]
+    public async Task BeforeStep_Metadata_Are_Correct()
+    {
+        var ctx = NewContext();
+
+        var seen = new List<(string Kind, string Title, StepPhase Phase, StepWord Word)>();
+
+        var pipe = new Pipeline(ctx)
+        {
+            BeforeStep = (_, m) => seen.Add((m.Kind, m.Title, m.Phase, m.Word))
+        };
+
+        pipe.Enqueue(StepPhase.Given, StepWord.Primary, "start", Const(1));
+        pipe.Enqueue(StepPhase.When, StepWord.Primary, "act", Const(2));
+        pipe.EnqueueInherit("and more", Const(3), StepWord.And);
+        pipe.EnqueueInherit("but alternative", Const(4), StepWord.But);
+
+        await pipe.RunAsync(CancellationToken.None);
+
+        Assert.Collection(seen,
+            m =>
+            {
+                var (kind, title, phase, word) = m;
+                Assert.Equal("Given", kind);
+                Assert.Equal("start", title);
+                Assert.Equal(StepPhase.Given, phase);
+                Assert.Equal(StepWord.Primary, word);
+            },
+            m =>
+            {
+                var (kind, title, phase, word) = m;
+                Assert.Equal("When", kind);
+                Assert.Equal("act", title);
+                Assert.Equal(StepPhase.When, phase);
+                Assert.Equal(StepWord.Primary, word);
+            },
+            m =>
+            {
+                var (kind, title, phase, word) = m;
+                Assert.Equal("And", kind);
+                Assert.Equal("and more", title);
+                Assert.Equal(StepPhase.When, phase);   // inherited
+                Assert.Equal(StepWord.And, word);
+            },
+            m =>
+            {
+                var (kind, title, phase, word) = m;
+                Assert.Equal("But", kind);
+                Assert.Equal("but alternative", title);
+                Assert.Equal(StepPhase.When, phase);   // inherited
+                Assert.Equal(StepWord.But, word);
+            });
+    }
+
+    [Scenario("AfterStep is invoked with results matching those recorded in ScenarioContext")]
+    [Fact]
+    public async Task AfterStep_Results_Match_Context_Steps()
+    {
+        var ctx = NewContext();
+
+        var after = new List<StepResult>();
+
+        var pipe = new Pipeline(ctx)
+        {
+            AfterStep = (_, r) => after.Add(r)
+        };
+
+        pipe.Enqueue(StepPhase.Given, StepWord.Primary, "seed", Const(1));
+        pipe.Enqueue(StepPhase.When, StepWord.Primary, "compute", Const(2));
+        pipe.Enqueue(StepPhase.Then, StepWord.Primary, "verify", Noop());
+
+        await pipe.RunAsync(CancellationToken.None);
+
+        // AfterStep fires once per executed step
+        Assert.Equal(3, after.Count);
+
+        // Compare AfterStep results with the context steps (order & fields)
+        Assert.Equal(ctx.Steps.Count, after.Count);
+        foreach (var (ctxStep, hookStep) in ctx.Steps.Zip(after))
+        {
+            Assert.Equal(ctxStep.Kind, hookStep.Kind);
+            Assert.Equal(ctxStep.Title, hookStep.Title);
+            Assert.Equal(ctxStep.Error?.GetType(), hookStep.Error?.GetType());
+        }
+    }
+
+    [Scenario("Hooks fire on failure; ContinueOnError=true records failure and continues")]
+    [Fact]
+    public async Task Hooks_On_Failure_With_ContinueOnError()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            ContinueOnError = true
+        });
+
+        var befores = new List<string>();
+        var afters = new List<(string Kind, string Title, Exception? Error)>();
+
+        var pipe = new Pipeline(ctx)
+        {
+            BeforeStep = (_, m) => befores.Add($"{m.Kind} {m.Title}"),
+            AfterStep = (_, r) => afters.Add((r.Kind, r.Title, r.Error))
+        };
+
+        pipe.Enqueue(StepPhase.Given, StepWord.Primary, "start", Const(1));
+        pipe.Enqueue(StepPhase.When, StepWord.Primary, "boom", (_, _) => throw new InvalidOperationException("kaboom"));
+        pipe.Enqueue(StepPhase.Then, StepWord.Primary, "after", Noop());
+
+        await pipe.RunAsync(CancellationToken.None);
+
+        // Hooks called for each step
+        Assert.Equal(3, befores.Count);
+        Assert.Equal(3, afters.Count);
+
+        // Middle step failed and was recorded as such
+        var failed = afters[1];
+        Assert.Equal("When", failed.Kind);
+        Assert.Equal("boom", failed.Title);
+        Assert.NotNull(failed.Error);
+        Assert.IsType<InvalidOperationException>(failed.Error);
+
+        // Final step executed and succeeded
+        var last = afters[^1];
+        Assert.Equal("Then", last.Kind);
+        Assert.Equal("after", last.Title);
+        Assert.Null(last.Error);
+    }
+
+    [Scenario("Title falls back to phase name when empty for both metadata and result")]
+    [Fact]
+    public async Task Empty_Title_Falls_Back_To_Phase()
+    {
+        var ctx = NewContext();
+
+        Pipeline.StepMetadata? firstMeta = null;
+        StepResult? firstResult = null;
+
+        var pipe = new Pipeline(ctx)
+        {
+            BeforeStep = (_, m) => firstMeta ??= m,
+            AfterStep  = (_, r) => firstResult ??= r
+        };
+
+        // Intentionally empty title
+        pipe.Enqueue(StepPhase.Given, StepWord.Primary, "", Const(42));
+
+        await pipe.RunAsync(CancellationToken.None);
+
+        Assert.NotNull(firstMeta);
+        Assert.Equal("Given", firstMeta!.Value.Kind);
+        Assert.Equal("Given", firstMeta.Value.Title);
+
+        Assert.NotNull(firstResult);
+        Assert.Equal("Given", firstResult!.Kind);
+        Assert.Equal("Given", firstResult.Title);
+        Assert.Null(firstResult.Error);
+    }
+    
+    [Scenario("StepMetadata init accessors are exercised via with-expression")]
+    [Fact]
+    public async Task StepMetadata_With_Expression_Sets_Init_Props()
+    {
+        var ctx = NewContext();
+
+        Pipeline.StepMetadata? captured = null;
+
+        var pipe = new Pipeline(ctx)
+        {
+            BeforeStep = (_, m) => captured ??= m
+        };
+
+        pipe.Enqueue(StepPhase.Given, StepWord.Primary, "start", Const(1));
+        await pipe.RunAsync(CancellationToken.None);
+
+        // we have an original metadata instance
+        var m = captured!.Value;
+
+        // exercise init-only setters via with-expression (hits init for ALL properties)
+        // ReSharper disable once WithExpressionModifiesAllMembers
+        var m2 = m with
+        {
+            Kind  = "CustomKind",
+            Title = "CustomTitle",
+            Phase = StepPhase.When,
+            Word  = StepWord.But
+        };
+
+        // original unchanged
+        Assert.Equal("Given", m.Kind);
+        Assert.Equal("start", m.Title);
+        Assert.Equal(StepPhase.Given, m.Phase);
+        Assert.Equal(StepWord.Primary, m.Word);
+
+        // cloned values reflect init changes
+        Assert.Equal("CustomKind", m2.Kind);
+        Assert.Equal("CustomTitle", m2.Title);
+        Assert.Equal(StepPhase.When, m2.Phase);
+        Assert.Equal(StepWord.But, m2.Word);
+    }
+}

--- a/tests/TinyBDD.Tests.Common/ScenarioOptionsTests.cs
+++ b/tests/TinyBDD.Tests.Common/ScenarioOptionsTests.cs
@@ -1,0 +1,130 @@
+namespace TinyBDD.Tests.Common;
+
+public class ScenarioOptionsTests
+{
+    [Feature("Options")]
+    private sealed class Host { }
+
+    [Scenario("HaltOnFailedAssertion = true causes assertion to throw immediately")]
+    [Fact]
+    public async Task HaltOnFailedAssertion_True_ThrowsAndRecordsStep()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            HaltOnFailedAssertion = true
+        });
+
+        var ex = await Assert.ThrowsAsync<BddAssertException>(async () =>
+            await Bdd.Given(ctx, "start", () => 1)
+                .Then("fail", v => v == 2)
+                .And("after", _ => Task.CompletedTask));
+
+        // failed assertion should be recorded
+        var failed = ctx.Steps.Last(x => x.Error is not null);
+        Assert.Equal("Then", failed.Kind);
+        Assert.Equal("fail", failed.Title);
+    }
+
+    [Scenario("HaltOnFailedAssertion = false records failure but continues")]
+    [Fact]
+    public async Task HaltOnFailedAssertion_False_RecordsFailureAndContinues()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            HaltOnFailedAssertion = false
+        });
+
+        await Bdd.Given(ctx, "start", () => 1)
+            .Then("fail", v => v == 2)
+            .And("after", _ => Task.CompletedTask);
+
+        // at least one failed step
+        ctx.AssertFailed();
+
+        var last = ctx.Steps.Last();
+        Assert.Equal("And", last.Kind);
+        Assert.Equal("after", last.Title);
+        Assert.Null(last.Error);
+    }
+
+    [Scenario("StepTimeout causes BddStepException and marks remaining steps as skipped when configured")]
+    [Fact]
+    public async Task StepTimeout_ThrowsAndSkipsRemaining_WhenConfigured()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            StepTimeout = TimeSpan.FromMilliseconds(50),
+            MarkRemainingAsSkippedOnFailure = true
+        });
+
+        var ex = await Assert.ThrowsAsync<BddStepException>(async () =>
+            await Bdd.Given(ctx, "start", () => 1)
+                .When("long", Long)
+                .Then("reached", _ => Task.CompletedTask));
+
+        // the errored step should be the Then since they get marked with an InvalidOperationException
+        var failed = ctx.Steps.Last(x => x.Error is not null);
+        Assert.Equal("Then", failed.Kind);
+        Assert.Equal("reached", failed.Title);
+
+        // the remaining Then should have been marked skipped
+        var last = ctx.Steps.Last();
+        Assert.Equal("Then", last.Kind);
+        Assert.Equal("reached", last.Title);
+        Assert.IsType<InvalidOperationException>(last.Error);
+        Assert.Equal("Skipped due to previous failure.", last.Error.Message);
+    }
+
+    [Scenario("ContinueOnError allows execution to continue after step timeout")]
+    [Fact]
+    public async Task StepTimeout_WithContinueOnError_DoesNotThrow_Continues()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            StepTimeout = TimeSpan.FromMilliseconds(50),
+            ContinueOnError = true
+        });
+
+        await Bdd.Given(ctx, "start", () => 1)
+            .When("long", Long)
+            .Then("reached", _ => Task.CompletedTask);
+
+        // no exception and Then executed
+        var last = ctx.Steps.Last();
+        Assert.Equal("Then", last.Kind);
+        Assert.Equal("reached", last.Title);
+        Assert.Null(last.Error);
+
+        // earlier failed step is recorded
+        var failed = ctx.Steps.Last(x => x.Error is not null);
+        Assert.Equal("When", failed.Kind);
+        Assert.Equal("long", failed.Title);
+    }
+
+    [Scenario("When a failure occurs and MarkRemainingAsSkippedOnFailure = false, remaining steps are not recorded (throw path)")]
+    [Fact]
+    public async Task Failure_NoMarkRemaining_DoesNotAddSkippedSteps()
+    {
+        var ctx = Bdd.CreateContext(new Host(), options: new ScenarioOptions
+        {
+            StepTimeout = TimeSpan.FromMilliseconds(50),
+            MarkRemainingAsSkippedOnFailure = false
+        });
+
+        await Assert.ThrowsAsync<BddStepException>(async () =>
+            await Bdd.Given(ctx, "start", () => 1)
+                .When("long", Long)
+                .Then("reached", _ => Task.CompletedTask));
+
+        // only the failing step should be present (no skipped Then)
+        Assert.Contains(ctx.Steps, s => s.Kind == "When" && s.Title == "long" && s.Error is not null);
+        Assert.DoesNotContain(ctx.Steps, s => s.Kind == "Then" && s.Title == "reached" && s.Error is not null && s.Error.Message == "Skipped due to previous failure.");
+    }
+    
+    
+    async Task<int> Long(int v, CancellationToken ct)
+    {
+        await Task.Delay(200, ct);
+        return v;
+    }
+}

--- a/tests/TinyBDD.Tests.Common/packages.lock.json
+++ b/tests/TinyBDD.Tests.Common/packages.lock.json
@@ -117,7 +117,8 @@
         "type": "Project",
         "dependencies": {
           "TinyBDD": "[1.0.0, )",
-          "xunit.abstractions": "[2.0.3, )"
+          "xunit.abstractions": "[2.0.3, )",
+          "xunit.extensibility.core": "[2.9.3, )"
         }
       },
       "xunit.abstractions": {

--- a/tests/TinyBDD.Xunit.Tests/packages.lock.json
+++ b/tests/TinyBDD.Xunit.Tests/packages.lock.json
@@ -117,7 +117,8 @@
         "type": "Project",
         "dependencies": {
           "TinyBDD": "[1.0.0, )",
-          "xunit.abstractions": "[2.0.3, )"
+          "xunit.abstractions": "[2.0.3, )",
+          "xunit.extensibility.core": "[2.9.3, )"
         }
       },
       "xunit.abstractions": {


### PR DESCRIPTION
Summary: Add a new `ScenarioOptions` record to configure scenario behavior (error handling, skipping, timeouts, and assertion halting) and thread the options through `ScenarioContext` and the pipeline. Update pipeline logic and tests to honor the new options.

### Details:

- **Added** `ScenarioOptions`
  - **File:** `src/TinyBDD/Core/ScenarioOptions.cs`
  - **Properties:**
    - `ContinueOnError`
    - `MarkRemainingAsSkippedOnFailure`
    - `StepTimeout`
    - `HaltOnFailedAssertion`

- **Exposed** options via `ScenarioContext.Options` and accept them in `Bdd.CreateContext(...)`.
- **Pipeline now respects options:**
  - `ContinueOnError` – allows execution to continue after step failures.
  - `MarkRemainingAsSkippedOnFailure` – marks remaining steps as skipped when configured.
  - `StepTimeout` – causes step timeouts to surface as `BddStepException` and can mark subsequent steps as skipped.
  - `HaltOnFailedAssertion` – causes assertion failures to throw immediately while recording the failed step.

- **Added/adjusted tests** to cover behaviors
  - **File:** `tests/TinyBDD.Tests.Common/ScenarioOptionsTests.cs`
  - Ensures existing scenarios remain backward-compatible.

### Notes
- **No breaking API changes** – defaults preserve previous behavior.